### PR TITLE
Add tag pages and make blog tags clickable

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -33,8 +33,7 @@ export default defineConfig({
   },
   // Redirects
   redirects: {
-    // TODO: create replacement pages for these
-    "/tags": "/",
+    "/tags": "/blog/tags",
     "/projects": "/",
     "/outdoors": "/",
     "/outdoors": "/",

--- a/src/components/BrutalPill.astro
+++ b/src/components/BrutalPill.astro
@@ -13,13 +13,18 @@ const { class: className = "bg-yellow-400", ...rest } = Astro.props;
     border-radius: 9999px;
     border: 2px solid black;
     padding: 0.25rem 0.75rem;
-    transition: all;
-    transition-duration: 0.5s;
-    animation: ease-in-out;
+    transition: filter 0.15s ease-out, transform 0.15s ease-out;
     font-size: small;
+    display: inline-block;
   }
 
   span.brutal-pill:hover {
     filter: drop-shadow(5px 5px 0 rgb(0 0 0 / 1));
+  }
+
+  span.brutal-pill:active {
+    filter: drop-shadow(0px 0px 0 rgb(0 0 0 / 1));
+    transform: translate(3px, 3px);
+    transition-duration: 0.05s;
   }
 </style>

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -2,12 +2,21 @@
 const navItems = [
   { href: "/", label: "Home" },
   { href: "/blog", label: "Blog" },
+  { href: "/blog/tags", label: "Tags" },
   { href: "/links", label: "Links" },
   { href: "/homelab", label: "Homelab" },
   { href: "/tools", label: "Tools" },
   { href: "/about", label: "About" },
 ];
 const currentUrl = Astro.url;
+const isActive = (href: string) => {
+  if (href === "/") return currentUrl.pathname === "/";
+  if (href.indexOf("/", 1) !== -1) {
+    // Multi-segment path: match exactly or as a prefix
+    return currentUrl.pathname === href || currentUrl.pathname.startsWith(href + "/");
+  }
+  return `/${currentUrl.pathname.split("/")[1]}` === href;
+};
 ---
 
 <nav
@@ -47,8 +56,7 @@ const currentUrl = Astro.url;
                     "text-white hover:text-slate-200 rounded-md px-3 py-2 text-xl font-bold",
                     {
                       "text-yellow-400 drop-shadow-2xl underline underline-offset-8 decoration-4":
-                        `/${currentUrl.pathname.split("/")[1]}` == item.href &&
-                        item.label != "samedwardes.com",
+                        isActive(item.href) && item.label != "samedwardes.com",
                     },
                   ]}
                   href={`${item.href}`}

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -2,10 +2,13 @@
 import { render } from "astro:content";
 import H1 from "../../components/H1.astro";
 import BrutalButton from "../../components/BrutalButton.astro";
+import BrutalPill from "../../components/BrutalPill.astro";
 import DefaultLayout from "../../layouts/DefaultLayout.astro";
 
 import { getCollection } from "astro:content";
 import TableOfContents from "../../components/TableOfContents.astro";
+
+const toTagSlug = (tag: string) => tag.toLowerCase().replace(/\s+/g, "-");
 
 export const prerender = true;
 
@@ -56,6 +59,16 @@ const { Content, headings } = await render(entry);
     {entry.data.date.getDate()},
     {entry.data.date.getFullYear()}
   </div>
+  <!-- Tags -->
+  {entry.data.tags && entry.data.tags.length > 0 && (
+    <div class="flex flex-row flex-wrap gap-2 mt-2">
+      {entry.data.tags.map((tag) => (
+        <a href={`/blog/tags/${toTagSlug(tag)}`}>
+          <BrutalPill class="bg-yellow-400">{tag}</BrutalPill>
+        </a>
+      ))}
+    </div>
+  )}
   <section class="grid grid-cols-12 gap-8 mt-4">
     <!-- Article content -->
     <article

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -4,6 +4,8 @@ import H1 from "../../components/H1.astro";
 import BrutalPill from "../../components/BrutalPill.astro";
 import { getCollection } from "astro:content";
 
+const toTagSlug = (tag: string) => tag.toLowerCase().replace(/\s+/g, "-");
+
 const blogEntries = (
   await getCollection("blog", ({ data }) => {
     return data.draft !== true;
@@ -38,7 +40,9 @@ const blogEntries = (
             <div class="flex flex-row flex-wrap gap-2">
               <div class="font-bold">Tags: </div>
               {blogPostEntry.data.tags?.map((tag) => (
-                <BrutalPill class="bg-yellow-400">{tag}</BrutalPill>
+                <a href={`/blog/tags/${toTagSlug(tag)}`}>
+                  <BrutalPill class="bg-yellow-400">{tag}</BrutalPill>
+                </a>
               ))}
             </div>
             <a

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -1,0 +1,80 @@
+---
+import DefaultLayout from "../../../layouts/DefaultLayout.astro";
+import H1 from "../../../components/H1.astro";
+import BrutalPill from "../../../components/BrutalPill.astro";
+import { getCollection } from "astro:content";
+
+export const prerender = true;
+
+const toTagSlug = (tag: string) => tag.toLowerCase().replace(/\s+/g, "-");
+
+export async function getStaticPaths() {
+  const toTagSlug = (tag: string) => tag.toLowerCase().replace(/\s+/g, "-");
+  const allEntries = await getCollection("blog", ({ data }) => data.draft !== true);
+
+  const tagMap = new Map<string, typeof allEntries>();
+  for (const entry of allEntries) {
+    for (const tag of entry.data.tags ?? []) {
+      const slug = toTagSlug(tag);
+      if (!tagMap.has(slug)) tagMap.set(slug, []);
+      tagMap.get(slug)!.push(entry);
+    }
+  }
+
+  return [...tagMap.entries()].map(([slug, posts]) => ({
+    params: { tag: slug },
+    props: {
+      tagName: posts[0].data.tags!.find((t) => toTagSlug(t) === slug)!,
+      posts: posts.sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf()),
+    },
+  }));
+}
+
+const { tagName, posts } = Astro.props;
+---
+
+<DefaultLayout metaTitle={`Tag: ${tagName}`}>
+  <H1>Posts tagged "{tagName}"</H1>
+  <ul>
+    {
+      posts.map((post) => (
+        <li class="pb-8">
+          <a
+            href={`/blog/${post.id}`}
+            class:list={[
+              "text-2xl font-bold text-primary",
+              "hover:text-primary hover:drop-shadow-lg hover:underline",
+            ]}
+          >
+            {post.data.title}
+          </a>
+          <div class="text-light text-gray-500">
+            {post.data.date.toLocaleString("default", { month: "long" })}
+            {post.data.date.getDate()},
+            {post.data.date.getFullYear()}
+          </div>
+          <div>{post.data.description}</div>
+          <div class="flex flex-row justify-between pt-2">
+            <div class="flex flex-row flex-wrap gap-2">
+              <div class="font-bold">Tags: </div>
+              {post.data.tags?.map((tag) => (
+                <a href={`/blog/tags/${toTagSlug(tag)}`}>
+                  <BrutalPill class="bg-yellow-400">{tag}</BrutalPill>
+                </a>
+              ))}
+            </div>
+            <a
+              href={`/blog/${post.id}`}
+              class:list={[
+                "font-bold text-primary",
+                "hover:text-primary hover:drop-shadow-lg hover:underline",
+              ]}
+            >
+              Read more
+            </a>
+          </div>
+        </li>
+      ))
+    }
+  </ul>
+</DefaultLayout>

--- a/src/pages/blog/tags/index.astro
+++ b/src/pages/blog/tags/index.astro
@@ -1,0 +1,38 @@
+---
+import DefaultLayout from "../../../layouts/DefaultLayout.astro";
+import H1 from "../../../components/H1.astro";
+import BrutalPill from "../../../components/BrutalPill.astro";
+import { getCollection } from "astro:content";
+
+const toTagSlug = (tag: string) => tag.toLowerCase().replace(/\s+/g, "-");
+
+const allEntries = await getCollection("blog", ({ data }) => data.draft !== true);
+
+const tagCounts = new Map<string, { name: string; count: number }>();
+for (const entry of allEntries) {
+  for (const tag of entry.data.tags ?? []) {
+    const slug = toTagSlug(tag);
+    if (!tagCounts.has(slug)) {
+      tagCounts.set(slug, { name: tag, count: 0 });
+    }
+    tagCounts.get(slug)!.count++;
+  }
+}
+
+const tags = [...tagCounts.values()].sort((a, b) => a.name.localeCompare(b.name));
+---
+
+<DefaultLayout metaTitle="Blog Tags">
+  <H1>Blog Tags</H1>
+  <div class="flex flex-row flex-wrap gap-3 mt-4">
+    {
+      tags.map(({ name, count }) => (
+        <a href={`/blog/tags/${toTagSlug(name)}`}>
+          <BrutalPill class="bg-yellow-400">
+            {name} ({count})
+          </BrutalPill>
+        </a>
+      ))
+    }
+  </div>
+</DefaultLayout>


### PR DESCRIPTION
Creates /blog/tags/[tag] archive pages listing all posts for a given tag,
a /blog/tags index listing all tags with counts, and wires up existing tag
pills on the blog index and individual post pages as links. Updates the
stale /tags redirect to point to the new /blog/tags page.

https://claude.ai/code/session_01Di3manvtCY8Scqep4wpVWw