### PR TITLE
Fix search results linking to /blog/undefined

### DIFF
--- a/src/pages/api/blog-posts.json.js
+++ b/src/pages/api/blog-posts.json.js
@@ -9,7 +9,7 @@ async function getPosts() {
 
   // return posts;
   return posts.map((post) => ({
-    slug: post.slug,
+    slug: post.id,
     title: post.data.title,
     description: post.data.description,
     tags: post.data.tags,


### PR DESCRIPTION
Clicking a search result returned a 404.

The search index API (`src/pages/api/blog-posts.json.js`) returned `post.slug`, which is `undefined` under Astro's Content Layer API (the `glob` loader). Every result link therefore pointed at `/blog/undefined`.

Use `post.id` instead, matching the value the blog route and blog index links already use.