### PR TITLE
Fix RSS feed links returning /blog/undefined

### DIFF
--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -12,7 +12,7 @@ export async function GET(context) {
       title: post.data.title,
       pubDate: post.data.date,
       description: post.data.description,
-      link: `/blog/${post.slug}`,
+      link: `/blog/${post.id}`,
     })),
     customData: `<language>en-us</language>`,
   });


### PR DESCRIPTION
## Problem

The RSS feed built links with `/blog/${post.slug}`. Under Astro's Content Layer API (the `glob` loader used in `content.config.ts`), collection entries expose `id`, not `slug`, so `post.slug` was `undefined`. Every feed link pointed to `/blog/undefined`, which 404s.

This is the same bug fixed for search results in aa7aa44; the RSS feed was missed.

## Fix

Change `post.slug` to `post.id` to match how the blog route (`[...slug].astro`) generates its paths.

## Verification

Built the site and inspected `dist/rss.xml`: links now resolve to real posts (e.g. `https://samedwardes.com/blog/2012-09-09-running-pei/`) with zero `/blog/undefined` entries.