### PR TITLE
Add view transitions to remove page flash on navigation

### DIFF
--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -22,7 +22,7 @@ const isActive = (href: string) => href === activeHref;
 ---
 
 <nav
-  class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-4 fixed z-[99] top-0 left-0 right-0"
+  class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-4 fixed z-[99] top-0 left-0 right-0 [view-transition-name:main-nav]"
 >
   <div
     class:list={[

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -14,6 +14,25 @@
   --color-primary: #3c7dc1;
 }
 
+@view-transition {
+  navigation: auto;
+}
+
+::view-transition-old(main-nav),
+::view-transition-new(main-nav) {
+  animation: none;
+  mix-blend-mode: normal;
+  height: 100%;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-group(*),
+  ::view-transition-old(*),
+  ::view-transition-new(*) {
+    animation: none !important;
+  }
+}
+
 @font-face {
   font-family: "Atkinson Hyperlegible";
   src: url("/fonts/Atkinson-Hyperlegible-Regular-102.woff") format("woff");


### PR DESCRIPTION
## What this does

Every click currently triggers a full browser page load, which flashes white and repaints the fixed nav bar. This enables native CSS cross-document view transitions so navigation cross-fades instead.

### Changes

- `src/styles/base.css`
  - `@view-transition { navigation: auto; }` enables cross-document view transitions, replacing the white flash with a smooth cross-fade.
  - A `main-nav` override disables the fade on the nav bar so it stays visually static across navigations.
  - A `prefers-reduced-motion` guard turns off the animations for users who opt out.
- `src/components/NavBar.astro`
  - Adds `[view-transition-name:main-nav]` to the `<nav>` element so the browser treats the nav as a persistent element.

No JavaScript changes and no new dependencies. Each page still fully loads, so Alpine, HTMX, the search script, and the TableOfContents observer keep working unchanged.

### Browser support

Chrome/Edge 126+ and Safari 18.2+ animate the transition. Firefox falls back to the current instant navigation with no errors.

### Verification

- `npm run build` passes; `@view-transition` and the `main-nav` utility are present in the compiled CSS.
- Manual: click between pages in Chrome/Safari to confirm no white flash and a stable nav bar with the active-link underline updating.