### PR TITLE
Reduce nav bar flicker on full page loads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,8 @@
     "": {
       "name": "samedwardes.com",
       "dependencies": {
+        "@alpinejs/focus": "^3.15.12",
+        "@alpinejs/ui": "^3.15.12",
         "@astrojs/check": "^0.9.8",
         "@astrojs/mdx": "^5.0.2",
         "@astrojs/netlify": "^7.0.3",
@@ -14,10 +16,12 @@
         "@notionhq/client": "^2.3.0",
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.2.2",
+        "alpinejs": "^3.15.12",
         "astro": "^6.0.7",
         "astro-expressive-code": "^0.41.7",
         "dompurify": "^3.3.3",
         "fuse.js": "^7.1.0",
+        "htmx.org": "^2.0.10",
         "marked": "^17.0.4",
         "sharp": "^0.34.5",
         "tailwindcss": "4",
@@ -25,12 +29,30 @@
         "vue": "^3.5.30"
       },
       "devDependencies": {
+        "@types/alpinejs": "^3.13.11",
+        "@types/alpinejs__focus": "^3.13.4",
         "@types/node": "^25.5.0",
         "daisyui": "^5.5.19",
         "husky": "^9.1.7",
         "prettier": "^3.8.1",
         "prettier-plugin-astro": "^0.14.1"
       }
+    },
+    "node_modules/@alpinejs/focus": {
+      "version": "3.15.12",
+      "resolved": "https://registry.npmjs.org/@alpinejs/focus/-/focus-3.15.12.tgz",
+      "integrity": "sha512-lmqbFTlbQGywDgsW4dY0pv18CKhuHJrq8mffU1OO14J34uUk+lCQElmSgJdRGHYv9qBezE6zdvmhN6n2tg0A1A==",
+      "license": "MIT",
+      "dependencies": {
+        "focus-trap": "^8.0.0",
+        "tabbable": "^6.4.0"
+      }
+    },
+    "node_modules/@alpinejs/ui": {
+      "version": "3.15.12",
+      "resolved": "https://registry.npmjs.org/@alpinejs/ui/-/ui-3.15.12.tgz",
+      "integrity": "sha512-dXZimOVJdoS15EczxIflnlaLOr3i6qDWtiUdSYqqI3jPWPD/mP9BmVOf7YjmFEzZ/theVH5kfJgLivcSVS2jjA==",
+      "license": "MIT"
     },
     "node_modules/@astrojs/check": {
       "version": "0.9.8",
@@ -4421,6 +4443,23 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@types/alpinejs": {
+      "version": "3.13.11",
+      "resolved": "https://registry.npmjs.org/@types/alpinejs/-/alpinejs-3.13.11.tgz",
+      "integrity": "sha512-3KhGkDixCPiLdL3Z/ok1GxHwLxEWqQOKJccgaQL01wc0EVM2tCTaqlC3NIedmxAXkVzt/V6VTM8qPgnOHKJ1MA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/alpinejs__focus": {
+      "version": "3.13.4",
+      "resolved": "https://registry.npmjs.org/@types/alpinejs__focus/-/alpinejs__focus-3.13.4.tgz",
+      "integrity": "sha512-g7pQNxST7palODhfg6DJoKWS59pD8EK1wNjkJydBP2u8LntlO8oD4f2uj6Ywh2CL/olM/bPSyYxwr+WQQPlphg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/alpinejs": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "license": "MIT",
@@ -4931,6 +4970,30 @@
       "peerDependencies": {
         "ajv": "^8.0.1"
       }
+    },
+    "node_modules/alpinejs": {
+      "version": "3.15.12",
+      "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.15.12.tgz",
+      "integrity": "sha512-nJvPAQVNPdZZ0NrExJ/kzQco3ijR8LwvCOadQecllESiqT4NyZ/57sN9V2XyvhlBGAbmlKYgeWZvYdKq99ij/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "~3.1.1"
+      }
+    },
+    "node_modules/alpinejs/node_modules/@vue/reactivity": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.1.5.tgz",
+      "integrity": "sha512-1tdfLmNjWG6t/CsPldh+foumYFo3cpyCHgBYQ34ylaMsJ+SNHQ1kApMIa8jN+i593zQuaw3AdWH0nJTARzCFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.1.5"
+      }
+    },
+    "node_modules/alpinejs/node_modules/@vue/shared": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.1.5.tgz",
+      "integrity": "sha512-oJ4F3TnvpXaQwZJNF3ZK+kLPHKarDmJjJ6jyzVNDKH9md1dptjC7lWR//jrGuLdek/U6iltWxqAnYOu8gCiOvA==",
+      "license": "MIT"
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -7653,6 +7716,15 @@
       "version": "1.1.0",
       "license": "MIT"
     },
+    "node_modules/focus-trap": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-8.2.2.tgz",
+      "integrity": "sha512-qV0g8hRYBqgACcFOH3f9wXc4zPKhr/0z9RI2a6ZijZ72EeBi4g8oBy8zAWuUR1TsMpOzwpUMFvjdasrC41Joug==",
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.5.0"
+      }
+    },
     "node_modules/fontace": {
       "version": "0.4.1",
       "license": "MIT",
@@ -8320,6 +8392,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/htmx.org": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.10.tgz",
+      "integrity": "sha512-kdeJe7ZVwaS6QMz/ebBIVtZdpwen6L0OQ5GOhPV9MKBb196TCZeZu4yA7ZIQsaLKv7EpXz+So7KSXNuHXhj7Cw==",
+      "license": "0BSD"
     },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
@@ -12887,6 +12965,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/tabbable": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "@alpinejs/focus": "^3.15.12",
+    "@alpinejs/ui": "^3.15.12",
     "@astrojs/check": "^0.9.8",
     "@astrojs/mdx": "^5.0.2",
     "@astrojs/netlify": "^7.0.3",
@@ -19,10 +21,12 @@
     "@notionhq/client": "^2.3.0",
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.2.2",
+    "alpinejs": "^3.15.12",
     "astro": "^6.0.7",
     "astro-expressive-code": "^0.41.7",
     "dompurify": "^3.3.3",
     "fuse.js": "^7.1.0",
+    "htmx.org": "^2.0.10",
     "marked": "^17.0.4",
     "sharp": "^0.34.5",
     "tailwindcss": "4",
@@ -30,6 +34,8 @@
     "vue": "^3.5.30"
   },
   "devDependencies": {
+    "@types/alpinejs": "^3.13.11",
+    "@types/alpinejs__focus": "^3.13.4",
     "@types/node": "^25.5.0",
     "daisyui": "^5.5.19",
     "husky": "^9.1.7",

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -26,7 +26,7 @@ const isActive = (href: string) => href === activeHref;
 >
   <div
     class:list={[
-      "navbar bg-primary rounded-2xl shadow-lg border-2 border-gray-900 opacity-90 h-16",
+      "navbar bg-primary rounded-2xl shadow-lg border-2 border-gray-900 h-16",
     ]}
   >
     <div class="navbar-start">

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -30,7 +30,7 @@ const isActive = (href: string) => href === activeHref;
     <div class="navbar-start">
       <!-- Mobile nav -->
       <div class="dropdown text-white">
-        <div tabindex="0" role="button" class="btn btn-ghost lg:hidden">
+        <div tabindex="0" role="button" class="lg:hidden">
           <svg
             xmlns="http://www.w3.org/2000/svg"
             class="h-5 w-5"
@@ -68,9 +68,7 @@ const isActive = (href: string) => href === activeHref;
           }
         </ul>
       </div>
-      <a class="font-bold text-xl text-white btn btn-ghost" href="/"
-        >samedwardes.com</a
-      >
+      <a class="font-bold text-xl text-white" href="/">samedwardes.com</a>
     </div>
     <!-- Desktop nav -->
     <div class="navbar-center hidden lg:flex">

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -21,9 +21,7 @@ const activeHref = navItems
 const isActive = (href: string) => href === activeHref;
 ---
 
-<nav
-  class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-4 fixed z-[99] top-0 left-0 right-0"
->
+<nav class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-4 sticky top-0 z-[99]">
   <div
     class:list={[
       "navbar bg-primary rounded-2xl shadow-lg border-2 border-gray-900 h-16",

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -22,7 +22,7 @@ const isActive = (href: string) => href === activeHref;
 ---
 
 <nav
-  class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-4 fixed z-[99] top-0 left-0 right-0 [view-transition-name:main-nav]"
+  class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-4 fixed z-[99] top-0 left-0 right-0"
 >
   <div
     class:list={[

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -2,6 +2,14 @@
 /// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />
 
+// @alpinejs/ui ships no type declarations and has no @types package.
+declare module "@alpinejs/ui" {
+  import type { PluginCallback } from "alpinejs";
+  const ui: PluginCallback;
+  export default ui;
+}
+
 interface Window {
   Alpine: import("alpinejs").Alpine;
+  htmx: typeof import("htmx.org").default;
 }

--- a/src/layouts/DefaultLayout.astro
+++ b/src/layouts/DefaultLayout.astro
@@ -54,7 +54,7 @@ import "../styles/base.css";
   </head>
   <body class="h-full">
     <NavBar />
-    <main class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 pb-4 pt-32">
+    <main class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 pb-4 pt-8">
       <div class:list={["container mx-auto", contentMaxWidth]}>
         <slot />
         <!-- your content is injected here -->

--- a/src/layouts/DefaultLayout.astro
+++ b/src/layouts/DefaultLayout.astro
@@ -18,26 +18,33 @@ import "../styles/base.css";
       title="samedwardes.com Blog"
       href="/rss.xml"
     />
-    <!-- Add the pro alpine JS stuff -->
-    <script
-      is:inline
-      defer
-      src="https://unpkg.com/@alpinejs/ui@3.14.1-beta.0/dist/cdn.min.js"
-    ></script>
-    <script
-      is:inline
-      defer
-      src="https://unpkg.com/@alpinejs/focus@3.14.1/dist/cdn.min.js"></script>
-    <script
-      is:inline
-      defer
-      src="https://unpkg.com/alpinejs@3.14.1/dist/cdn.min.js"></script>
-    <!-- Add HTMX -->
-    <script
-      is:inline
-      src="https://unpkg.com/htmx.org@2.0.1"
-      integrity="sha384-QWGpdj554B4ETpJJC9z+ZHJcA/i59TyjxEPXiiUgN2WmTyV5OEZWCD6gQhgkdpB/"
-      crossorigin="anonymous"></script>
+    <link
+      rel="preload"
+      href="/fonts/Atkinson-Hyperlegible-Regular-102.woff"
+      as="font"
+      type="font/woff"
+      crossorigin
+    />
+    <link
+      rel="preload"
+      href="/fonts/Atkinson-Hyperlegible-Bold-102.woff"
+      as="font"
+      type="font/woff"
+      crossorigin
+    />
+    <!-- Bundle Alpine (core + focus + ui) and HTMX as same-origin assets -->
+    <script>
+      import Alpine from "alpinejs";
+      import focus from "@alpinejs/focus";
+      import ui from "@alpinejs/ui";
+      import htmx from "htmx.org";
+
+      window.htmx = htmx;
+      Alpine.plugin(focus);
+      Alpine.plugin(ui);
+      window.Alpine = Alpine;
+      Alpine.start();
+    </script>
     <!--Umami for analytics-->
     <script
       is:inline

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -14,25 +14,6 @@
   --color-primary: #3c7dc1;
 }
 
-@view-transition {
-  navigation: auto;
-}
-
-::view-transition-old(main-nav),
-::view-transition-new(main-nav) {
-  animation: none;
-  mix-blend-mode: normal;
-  height: 100%;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  ::view-transition-group(*),
-  ::view-transition-old(*),
-  ::view-transition-new(*) {
-    animation: none !important;
-  }
-}
-
 @font-face {
   font-family: "Atkinson Hyperlegible";
   src: url("/fonts/Atkinson-Hyperlegible-Regular-102.woff") format("woff");


### PR DESCRIPTION
Reduces three causes of the nav bar repainting on every full page navigation (issue #105).

## Changes
- **Preload fonts**: Add `<link rel="preload">` for the Regular and Bold Atkinson Hyperlegible woff files (already self-hosted) so nav text no longer swaps from a fallback after first paint.
- **Opaque nav**: Remove `opacity-90` from the nav bar so it renders solid instead of as a semi-transparent compositing layer that re-blends on each repaint.
- **Bundle scripts**: Move Alpine (core, focus, ui) and HTMX off unpkg into same-origin npm deps bundled by Astro. Umami stays remote (hosted service). Adds `@types/alpinejs` and `@types/alpinejs__focus`, plus an `env.d.ts` shim for `@alpinejs/ui` (no published types) and `window.htmx` typing.

## Verification
- `npm run build` passes with no type errors.
- `grep unpkg dist/` returns nothing; scripts are now same-origin.
- Dev server: home page serves an opaque nav with both font preloads, the Tabs component still renders `x-tabs` (Alpine), and `/links` plus its `/links/partials/grid` HTMX endpoint both respond 200.

Closes #105